### PR TITLE
fix(repo): Change name to virtualout instead of Vi

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Vi
+Copyright (c) 2021 virtualout
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Changed to avoid potential legal trouble and to make it actually make sense